### PR TITLE
CocoonJS Support

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1,8 +1,7 @@
-var domify = require('domify'),
-    templates = require("./templates");
-
 module.exports = render;
 
-function render(src){
-  return domify(templates['audio.html']);
+function render(){
+  var audio = new Audio();
+  audio.preload = 'auto';
+  return audio;
 }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,1 +1,0 @@
-exports["audio.html"] = "<audio preload=\"auto\" /></audio>"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "fox"
   },
   "dependencies": {
-    "new-chain": "*",
-    "domify": "~1.0.0"
+    "new-chain": "*"
   },
   "devDependencies": {
     "fox": "*",


### PR DESCRIPTION
Using the generic Audio type instead of relying on the DOM allows it to work in CocoonJS.
